### PR TITLE
修复 Intel 核显下 Antichrist beam shader 启动崩溃

### DIFF
--- a/src/main/java/com/gtladd/gtladditions/client/render/machine/antichrist/AntichristBeamRenderer.kt
+++ b/src/main/java/com/gtladd/gtladditions/client/render/machine/antichrist/AntichristBeamRenderer.kt
@@ -6,7 +6,6 @@ import com.gtladd.gtladditions.client.render.withPose
 import com.mojang.blaze3d.platform.GlStateManager
 import com.mojang.blaze3d.systems.RenderSystem
 import com.mojang.blaze3d.vertex.BufferBuilder
-import com.mojang.blaze3d.vertex.DefaultVertexFormat
 import com.mojang.blaze3d.vertex.PoseStack
 import com.mojang.blaze3d.vertex.Tesselator
 import com.mojang.blaze3d.vertex.VertexBuffer
@@ -24,6 +23,7 @@ import kotlin.math.asin
 import kotlin.math.atan2
 import kotlin.math.cos
 import kotlin.math.max
+import kotlin.math.roundToInt
 import kotlin.math.sin
 import kotlin.math.sqrt
 
@@ -33,6 +33,7 @@ object AntichristBeamRenderer {
     private const val SEGMENT_QUADS = 16
     private const val ENDPOINT_FLOATS = (MAX_SEGMENTS + 1) * 3
     private const val PI = 3.1415926535897f
+    private const val ALPHA_PACK_SCALE = 10000.0f
     private const val BACK_PLATE_DISTANCE = -121.5f
     private const val BACK_PLATE_RADIUS = 13.0f
     private const val INTENSE_BEAM_TANGENT_FADE_DISTANCE = 3.75f
@@ -134,6 +135,7 @@ object AntichristBeamRenderer {
         shader.getUniform("Intensity")?.set(2.0f)
         uploadBeamBuffer(softBeam, tick)
         DeferredOculusCompat.withDeferredShaderPass {
+            beamBuffer.bind()
             beamBuffer.drawWithShader(last().pose(), RenderSystem.getProjectionMatrix(), shader)
         }
 
@@ -141,6 +143,7 @@ object AntichristBeamRenderer {
         shader.getUniform("Intensity")?.set(4.0f)
         uploadBeamBuffer(intenseBeam, tick)
         DeferredOculusCompat.withDeferredShaderPass {
+            beamBuffer.bind()
             beamBuffer.drawWithShader(last().pose(), RenderSystem.getProjectionMatrix(), shader)
         }
 
@@ -338,7 +341,7 @@ object AntichristBeamRenderer {
 
     private fun uploadBeamBuffer(segments: SegmentBuffer, tick: Float) {
         val builder = Tesselator.getInstance().builder
-        builder.begin(VertexFormat.Mode.TRIANGLES, DefaultVertexFormat.POSITION_TEX_COLOR)
+        builder.begin(VertexFormat.Mode.TRIANGLES, AntichristShaders.BEAM_VERTEX_FORMAT)
         writeBeamVertices(builder, segments, tick)
 
         beamBuffer.bind()
@@ -375,13 +378,18 @@ object AntichristBeamRenderer {
         val y = sin(angle) * radius
         val timer = tick / 240.0f
         val heightOffset = (offset / 256.0f) + timer
-        val alpha = (segments.transparency(endpointId).coerceIn(0.0f, 1.0f) * 255.0f).toInt()
+        val alpha = packAlpha(segments.transparency(endpointId))
 
         builder.vertex(x.toDouble(), y.toDouble(), offset.toDouble())
             .uv(heightOffset, angle / (2.0f * PI) + heightOffset / 3.0f + timer)
-            .color(255, 255, 255, alpha)
+            .overlayCoords(alpha)
             .endVertex()
     }
+
+    private fun packAlpha(alpha: Float): Int =
+        (alpha * ALPHA_PACK_SCALE)
+            .roundToInt()
+            .coerceIn(Short.MIN_VALUE.toInt(), Short.MAX_VALUE.toInt()) and 0xFFFF
 
     private fun getVertexAngle(quadId: Int, localId: Int, cameraAngle: Float): Float {
         val idOffset = if (localId > 1 && localId < 5) 0 else 1

--- a/src/main/java/com/gtladd/gtladditions/client/render/machine/antichrist/AntichristBeamRenderer.kt
+++ b/src/main/java/com/gtladd/gtladditions/client/render/machine/antichrist/AntichristBeamRenderer.kt
@@ -32,6 +32,7 @@ object AntichristBeamRenderer {
     private const val MAX_SEGMENTS = 10
     private const val SEGMENT_QUADS = 16
     private const val ENDPOINT_FLOATS = (MAX_SEGMENTS + 1) * 3
+    private const val PI = 3.1415926535897f
     private const val BACK_PLATE_DISTANCE = -121.5f
     private const val BACK_PLATE_RADIUS = 13.0f
     private const val INTENSE_BEAM_TANGENT_FADE_DISTANCE = 3.75f
@@ -39,7 +40,7 @@ object AntichristBeamRenderer {
     private val SPACE_LAYER = GTLAdditions.id("textures/block/multiblock/forge_of_antichrist/space_layer.png")
 
     private val beamBuffer: VertexBuffer by lazy {
-        buildBeamBuffer()
+        VertexBuffer(VertexBuffer.Usage.DYNAMIC)
     }
 
     private val softBeam = SegmentBuffer()
@@ -127,22 +128,18 @@ object AntichristBeamRenderer {
         RenderSystem.disableCull()
         RenderSystem.setShaderTexture(0, SPACE_LAYER)
 
-        shader.getUniform("SegmentQuads")?.set(SEGMENT_QUADS.toFloat())
         shader.getUniform("CameraPosition")?.set(cameraPosition.x, cameraPosition.y, cameraPosition.z)
-        shader.getUniform("Time")?.set(tick)
 
-        beamBuffer.bind()
-
-        shader.getUniform("Color")?.set(colorR, colorG, colorB)
+        shader.getUniform("BeamColor")?.set(colorR, colorG, colorB)
         shader.getUniform("Intensity")?.set(2.0f)
-        shader.getUniform("SegmentArray")?.set(softBeam.values)
+        uploadBeamBuffer(softBeam, tick)
         DeferredOculusCompat.withDeferredShaderPass {
             beamBuffer.drawWithShader(last().pose(), RenderSystem.getProjectionMatrix(), shader)
         }
 
-        shader.getUniform("Color")?.set(intenseColorR, intenseColorG, intenseColorB)
+        shader.getUniform("BeamColor")?.set(intenseColorR, intenseColorG, intenseColorB)
         shader.getUniform("Intensity")?.set(4.0f)
-        shader.getUniform("SegmentArray")?.set(intenseBeam.values)
+        uploadBeamBuffer(intenseBeam, tick)
         DeferredOculusCompat.withDeferredShaderPass {
             beamBuffer.drawWithShader(last().pose(), RenderSystem.getProjectionMatrix(), shader)
         }
@@ -339,23 +336,56 @@ object AntichristBeamRenderer {
     private fun interpolate(x0: Float, x1: Float, y0: Float, y1: Float, x: Float): Float =
         y0 + ((x - x0) * (y1 - y0)) / (x1 - x0)
 
-    private fun buildBeamBuffer(): VertexBuffer {
-        val buffer = VertexBuffer(VertexBuffer.Usage.STATIC)
+    private fun uploadBeamBuffer(segments: SegmentBuffer, tick: Float) {
         val builder = Tesselator.getInstance().builder
-        builder.begin(VertexFormat.Mode.TRIANGLES, DefaultVertexFormat.POSITION)
+        builder.begin(VertexFormat.Mode.TRIANGLES, DefaultVertexFormat.POSITION_TEX_COLOR)
+        writeBeamVertices(builder, segments, tick)
 
-        repeat(MAX_SEGMENTS * SEGMENT_QUADS * 6) {
-            addVertex(builder)
-        }
-
-        buffer.bind()
-        buffer.upload(builder.end())
-        VertexBuffer.unbind()
-        return buffer
+        beamBuffer.bind()
+        beamBuffer.upload(builder.end())
     }
 
-    private fun addVertex(builder: BufferBuilder) {
-        builder.vertex(0.0, 0.0, 0.0).endVertex()
+    private fun writeBeamVertices(builder: BufferBuilder, segments: SegmentBuffer, tick: Float) {
+        val cameraAngle = atan2(cameraPosition.y, cameraPosition.x)
+        for (segmentId in 0 until MAX_SEGMENTS) {
+            for (quadId in 0 until SEGMENT_QUADS) {
+                addBeamVertex(builder, segments, segmentId + 1, quadId, 0, cameraAngle, tick)
+                addBeamVertex(builder, segments, segmentId, quadId, 1, cameraAngle, tick)
+                addBeamVertex(builder, segments, segmentId, quadId, 2, cameraAngle, tick)
+                addBeamVertex(builder, segments, segmentId, quadId, 3, cameraAngle, tick)
+                addBeamVertex(builder, segments, segmentId + 1, quadId, 4, cameraAngle, tick)
+                addBeamVertex(builder, segments, segmentId + 1, quadId, 5, cameraAngle, tick)
+            }
+        }
+    }
+
+    private fun addBeamVertex(
+        builder: BufferBuilder,
+        segments: SegmentBuffer,
+        endpointId: Int,
+        quadId: Int,
+        localId: Int,
+        cameraAngle: Float,
+        tick: Float
+    ) {
+        val radius = segments.radius(endpointId)
+        val offset = segments.offset(endpointId)
+        val angle = getVertexAngle(quadId, localId, cameraAngle)
+        val x = cos(angle) * radius
+        val y = sin(angle) * radius
+        val timer = tick / 240.0f
+        val heightOffset = (offset / 256.0f) + timer
+        val alpha = (segments.transparency(endpointId).coerceIn(0.0f, 1.0f) * 255.0f).toInt()
+
+        builder.vertex(x.toDouble(), y.toDouble(), offset.toDouble())
+            .uv(heightOffset, angle / (2.0f * PI) + heightOffset / 3.0f + timer)
+            .color(255, 255, 255, alpha)
+            .endVertex()
+    }
+
+    private fun getVertexAngle(quadId: Int, localId: Int, cameraAngle: Float): Float {
+        val idOffset = if (localId > 1 && localId < 5) 0 else 1
+        return (PI * (quadId + idOffset).toFloat()) / SEGMENT_QUADS.toFloat() + (cameraAngle - PI / 2.0f)
     }
 
     private class SegmentBuffer {
@@ -383,5 +413,11 @@ object AntichristBeamRenderer {
                 values[base + 2] = values[fallbackBase + 2]
             }
         }
+
+        fun radius(endpointId: Int): Float = values[endpointId * 3]
+
+        fun offset(endpointId: Int): Float = values[endpointId * 3 + 1]
+
+        fun transparency(endpointId: Int): Float = values[endpointId * 3 + 2]
     }
 }

--- a/src/main/java/com/gtladd/gtladditions/client/render/machine/antichrist/AntichristShaders.kt
+++ b/src/main/java/com/gtladd/gtladditions/client/render/machine/antichrist/AntichristShaders.kt
@@ -26,7 +26,7 @@ object AntichristShaders {
         ) { shader -> starShader = shader }
 
         event.registerShader(
-            ShaderInstance(event.resourceProvider, BEAM_SHADER_ID, DefaultVertexFormat.POSITION)
+            ShaderInstance(event.resourceProvider, BEAM_SHADER_ID, DefaultVertexFormat.POSITION_TEX_COLOR)
         ) { shader -> beamShader = shader }
     }
 }

--- a/src/main/java/com/gtladd/gtladditions/client/render/machine/antichrist/AntichristShaders.kt
+++ b/src/main/java/com/gtladd/gtladditions/client/render/machine/antichrist/AntichristShaders.kt
@@ -1,7 +1,9 @@
 package com.gtladd.gtladditions.client.render.machine.antichrist
 
+import com.google.common.collect.ImmutableMap
 import com.gtladd.gtladditions.GTLAdditions
 import com.mojang.blaze3d.vertex.DefaultVertexFormat
+import com.mojang.blaze3d.vertex.VertexFormat
 import net.minecraft.client.renderer.ShaderInstance
 import net.minecraftforge.api.distmarker.Dist
 import net.minecraftforge.api.distmarker.OnlyIn
@@ -13,6 +15,16 @@ import net.minecraftforge.fml.common.Mod
 object AntichristShaders {
     private val STAR_SHADER_ID = GTLAdditions.id("gtladditions_antichrist_star")
     private val BEAM_SHADER_ID = GTLAdditions.id("gtladditions_antichrist_beam")
+    internal val BEAM_VERTEX_FORMAT = VertexFormat(
+        ImmutableMap.of(
+            "Position",
+            DefaultVertexFormat.ELEMENT_POSITION,
+            "UV0",
+            DefaultVertexFormat.ELEMENT_UV0,
+            "UV1",
+            DefaultVertexFormat.ELEMENT_UV1
+        )
+    )
 
     var starShader: ShaderInstance? = null
         private set
@@ -26,7 +38,7 @@ object AntichristShaders {
         ) { shader -> starShader = shader }
 
         event.registerShader(
-            ShaderInstance(event.resourceProvider, BEAM_SHADER_ID, DefaultVertexFormat.POSITION_TEX_COLOR)
+            ShaderInstance(event.resourceProvider, BEAM_SHADER_ID, BEAM_VERTEX_FORMAT)
         ) { shader -> beamShader = shader }
     }
 }

--- a/src/main/resources/assets/gtladditions/shaders/core/gtladditions_antichrist_beam.fsh
+++ b/src/main/resources/assets/gtladditions/shaders/core/gtladditions_antichrist_beam.fsh
@@ -3,7 +3,7 @@
 uniform sampler2D Sampler0;
 uniform float Intensity;
 uniform vec3 CameraPosition;
-uniform vec3 Color;
+uniform vec3 BeamColor;
 
 in vec2 texCoord;
 in vec2 localPosition;
@@ -24,5 +24,5 @@ void main() {
     float luminance = 1.0 - luminanceTransform(texColor.xyz);
     luminance = mix(luminance, 1.0, 1.0 - pow(angleAlpha, 6.0));
     float alpha = clamp(angleAlpha * transparency * luminance, 0.0, 1.0);
-    fragColor = vec4(Color, alpha);
+    fragColor = vec4(BeamColor, alpha);
 }

--- a/src/main/resources/assets/gtladditions/shaders/core/gtladditions_antichrist_beam.json
+++ b/src/main/resources/assets/gtladditions/shaders/core/gtladditions_antichrist_beam.json
@@ -7,7 +7,9 @@
   "vertex": "gtladditions:gtladditions_antichrist_beam",
   "fragment": "gtladditions:gtladditions_antichrist_beam",
   "attributes": [
-    "Position"
+    "Position",
+    "UV0",
+    "Color"
   ],
   "samplers": [
     {
@@ -62,30 +64,6 @@
       ]
     },
     {
-      "name": "SegmentQuads",
-      "type": "float",
-      "count": 1,
-      "values": [
-        16.0
-      ]
-    },
-    {
-      "name": "Time",
-      "type": "float",
-      "count": 1,
-      "values": [
-        0.0
-      ]
-    },
-    {
-      "name": "SegmentArray",
-      "type": "float",
-      "count": 33,
-      "values": [
-        0.0
-      ]
-    },
-    {
       "name": "CameraPosition",
       "type": "float",
       "count": 3,
@@ -96,7 +74,7 @@
       ]
     },
     {
-      "name": "Color",
+      "name": "BeamColor",
       "type": "float",
       "count": 3,
       "values": [

--- a/src/main/resources/assets/gtladditions/shaders/core/gtladditions_antichrist_beam.json
+++ b/src/main/resources/assets/gtladditions/shaders/core/gtladditions_antichrist_beam.json
@@ -9,7 +9,7 @@
   "attributes": [
     "Position",
     "UV0",
-    "Color"
+    "UV1"
   ],
   "samplers": [
     {

--- a/src/main/resources/assets/gtladditions/shaders/core/gtladditions_antichrist_beam.vsh
+++ b/src/main/resources/assets/gtladditions/shaders/core/gtladditions_antichrist_beam.vsh
@@ -1,63 +1,19 @@
 #version 150
 
 in vec3 Position;
+in vec2 UV0;
+in vec4 Color;
 
 uniform mat4 ModelViewMat;
 uniform mat4 ProjMat;
-uniform float SegmentQuads;
-uniform float Time;
-uniform float SegmentArray[33];
-uniform vec3 CameraPosition;
 
 out vec2 texCoord;
 out vec2 localPosition;
 out float transparency;
 
-const float PI = 3.1415926535897;
-const int MAX_SEGMENTS = 10;
-
-vec3 segmentEndpoint(int endpointId) {
-    int base = endpointId * 3;
-    return vec3(SegmentArray[base], SegmentArray[base + 1], SegmentArray[base + 2]);
-}
-
-float getAngle(int quadId, int localId) {
-    int idOffset = (localId > 1 && localId < 5) ? 0 : 1;
-    return (PI * float(quadId + idOffset)) / SegmentQuads;
-}
-
 void main() {
-    int id = gl_VertexID;
-    int quads = int(SegmentQuads);
-    int localId = id % 6;
-    int quadId = (id / 6) % quads;
-    int segmentId = id / (quads * 6);
-    segmentId = min(segmentId, MAX_SEGMENTS - 1);
-
-    vec3 startSegment = segmentEndpoint(segmentId);
-    vec3 endSegment = segmentEndpoint(segmentId + 1);
-
-    float radius0 = startSegment.x;
-    float radius1 = endSegment.x;
-    float offset0 = startSegment.y;
-    float offset1 = endSegment.y;
-    float trans0 = startSegment.z;
-    float trans1 = endSegment.z;
-
-    float cameraAngle = atan(CameraPosition.y, CameraPosition.x);
-    float staticAngle = getAngle(quadId, localId);
-    float angle = staticAngle + (cameraAngle - PI / 2.0);
-
-    float offset = (localId > 0 && localId < 4) ? offset0 : offset1;
-    float radius = (localId > 0 && localId < 4) ? radius0 : radius1;
-    transparency = (localId > 0 && localId < 4) ? trans0 : trans1;
-
-    vec3 localPos = vec3(cos(angle) * radius, sin(angle) * radius, offset);
-    gl_Position = ProjMat * ModelViewMat * vec4(localPos, 1.0);
-
-    localPosition = localPos.xy;
-
-    float timer = Time / 240.0;
-    float heightOffset = (offset / 256.0) + timer;
-    texCoord = vec2(heightOffset, angle / (2.0 * PI) + heightOffset / 3.0 + timer);
+    texCoord = UV0;
+    localPosition = Position.xy;
+    transparency = Color.a;
+    gl_Position = ProjMat * ModelViewMat * vec4(Position, 1.0);
 }

--- a/src/main/resources/assets/gtladditions/shaders/core/gtladditions_antichrist_beam.vsh
+++ b/src/main/resources/assets/gtladditions/shaders/core/gtladditions_antichrist_beam.vsh
@@ -2,7 +2,7 @@
 
 in vec3 Position;
 in vec2 UV0;
-in vec4 Color;
+in ivec2 UV1;
 
 uniform mat4 ModelViewMat;
 uniform mat4 ProjMat;
@@ -14,6 +14,6 @@ out float transparency;
 void main() {
     texCoord = UV0;
     localPosition = Position.xy;
-    transparency = Color.a;
+    transparency = float(UV1.x) / 10000.0;
     gl_Position = ProjMat * ModelViewMat * vec4(Position, 1.0);
 }


### PR DESCRIPTION
> 此 PR 由 AI 生成

fix https://github.com/Dragonators/GTLAdditions/issues/26

## 问题原因

`gtladditions_antichrist_beam.vsh` 在顶点着色器中通过 `gl_VertexID` 生成 beam 几何，并使用动态下标访问 `uniform float SegmentArray[33]`。

该写法在部分环境可正常编译，但会触发 Intel Iris Xe Windows OpenGL 驱动崩溃：

- GPU: Intel Iris Xe Graphics
- OpenGL driver: 32.0.101.6733
- 表现: 客户端启动资源加载阶段原生崩溃，退出码 `-1073740791 / 0xC0000409`

## 修复方案

将 beam 几何生成从 GLSL 移到 Kotlin 渲染器中。

现在 `AntichristBeamRenderer` 直接生成真实顶点，并使用 `POSITION_TEX_COLOR` 上传：

- `Position`: beam 顶点位置
- `UV0`: 贴图坐标
- `Color.a`: 顶点透明度

beam 顶点着色器只做简单传递和矩阵变换，避免触发 Intel 驱动问题。

## 主要变化

- 移除 `gl_VertexID` 几何生成
- 移除 `SegmentArray[33]` 动态 uniform 数组索引
- 移除 `SegmentQuads` uniform 计算